### PR TITLE
doc: enable adbkeyboard via adb command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ADB 调试能力，可通过 WiFi 或网络连接设备，实现灵活的远程�
 ### 4. 安装 ADB Keyboard（用于文本输入）
 
 下载 [安装包](https://github.com/senzhk/ADBKeyBoard/blob/master/ADBKeyboard.apk) 并在对应的安卓设备中进行安装。
-注意，安装完成后还需要到 `设置-输入法` 或者 `设置-键盘列表` 中启用 `ADB Keyboard` 才能生效
+注意，安装完成后还需要到 `设置-输入法` 或者 `设置-键盘列表` 中启用 `ADB Keyboard` 才能生效(或使用命令`adb shell ime enable com.android.adbkeyboard/.AdbIME`[How-to-use](https://github.com/senzhk/ADBKeyBoard/blob/master/README.md#how-to-use))
 
 ## 部署准备工作
 

--- a/README_en.md
+++ b/README_en.md
@@ -56,7 +56,7 @@ Python 3.10 or higher is recommended.
 ### 4. Install ADB Keyboard (for Text Input)
 
 Download the [installation package](https://github.com/senzhk/ADBKeyBoard/blob/master/ADBKeyboard.apk) and install it on the corresponding Android device.
-Note: After installation, you need to enable `ADB Keyboard` in `Settings > Input Method` or `Settings > Keyboard List` for it to work.
+Note: After installation, you need to enable `ADB Keyboard` in `Settings > Input Method` or `Settings > Keyboard List` for it to work.(or use command `adb shell ime enable com.android.adbkeyboard/.AdbIME`[How-to-use](https://github.com/senzhk/ADBKeyBoard/blob/master/README.md#how-to-use))
 
 ## Deployment Preparation
 


### PR DESCRIPTION
ADBKeyboad is not listed at `Settings > Input Method` or `Settings > Keyboard List` on my Redmi K40Pro. It can only be enabled via command.