### PR TITLE
Redefine python version in README.md & README_en.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ADB 调试能力，可通过 WiFi 或网络连接设备，实现灵活的远程�
 
 ### 1. Python 环境
 
-建议使用 Python 3.10 及以上版本。
+建议使用 Python 3.10 - 3.12 版本。
 
 ### 2. ADB (Android Debug Bridge)
 

--- a/README_en.md
+++ b/README_en.md
@@ -28,7 +28,7 @@ Phone Agent is a mobile intelligent assistant framework built on AutoGLM. It und
 
 ### 1. Python Environment
 
-Python 3.10 or higher is recommended.
+Python from 3.10 to 3.12 is recommended.
 
 ### 2. ADB (Android Debug Bridge)
 


### PR DESCRIPTION
This PR fixes a typo or improves the documentation。

When I tried to install  build dependencies, an error appeared. Could not find a version that satisfies the requirement decord2 (from sglang). So I think python versions from 3.9 to 3.12 is  more suitable for this project.

<img width="2310" height="241" alt="image" src="https://github.com/user-attachments/assets/b0c0328a-8fad-4dde-af35-914e455f2742" />
 