### PR TITLE
Add modelscope support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,30 @@ adb devices
 
 ### 3. 启动模型服务
 
+你可以选择自行部署模型服务，或使用第三方模型服务商。
+
+#### 选项 A: 使用第三方模型服务
+
+如果你不想自行部署模型，可以使用以下已部署我们模型的第三方服务：
+
+**1. ModelScope（魔搭社区）**
+
+- 文档: https://modelscope.cn/models/ZhipuAI/AutoGLM-Phone-9B
+- `--base-url`: `https://api-inference.modelscope.cn/v1`
+- `--model`: `ZhipuAI/AutoGLM-Phone-9B`
+- `--apikey`: 在 ModelScope 平台申请你的 API Key
+
+使用第三方服务的示例：
+
+```bash
+# 使用 ModelScope
+python main.py --base-url https://api-inference.modelscope.cn/v1 --model "ZhipuAI/AutoGLM-Phone-9B" --apikey "your-modelscope-api-key" "打开美团搜索附近的火锅店"
+```
+
+#### 选项 B: 自行部署模型
+
+如果你希望在本地或自己的服务器上部署模型：
+
 1. 按照 `requirements.txt` 中 `For Model Deployment` 章节自行安装推理引擎框架。
 
 对于SGLang， 除了使用pip安装，你也可以使用官方docker:


### PR DESCRIPTION
  Summary

  - 在 README 中新增 ModelScope（魔搭社区）第三方模型服务的使用说明
  - 重构"启动模型服务"章节，将其拆分为"使用第三方服务"和"自行部署模型"两个选项
  - 提供 ModelScope 的 API 接入配置和使用示例

  Test plan

  - 验证 README 中的 ModelScope 链接可正常访问
  - 验证示例命令格式正确