### PR TITLE
support stream thinking

### DIFF
--- a/phone_agent/agent.py
+++ b/phone_agent/agent.py
@@ -169,6 +169,10 @@ class PhoneAgent:
 
         # Get model response
         try:
+            msgs = get_messages(self.agent_config.lang)
+            print("\n" + "=" * 50)
+            print(f"💭 {msgs['thinking']}:")
+            print("-" * 50)
             response = self.model_client.request(self._context)
         except Exception as e:
             if self.agent_config.verbose:
@@ -191,11 +195,6 @@ class PhoneAgent:
 
         if self.agent_config.verbose:
             # Print thinking process
-            msgs = get_messages(self.agent_config.lang)
-            print("\n" + "=" * 50)
-            print(f"💭 {msgs['thinking']}:")
-            print("-" * 50)
-            print(response.thinking)
             print("-" * 50)
             print(f"🎯 {msgs['action']}:")
             print(json.dumps(action, ensure_ascii=False, indent=2))


### PR DESCRIPTION
   ## Changes

   ### Model Client (`phone_agent/model/client.py`)
   - **Enable streaming mode**: Changed `stream=False` to `stream=True` in the API request
   - **Implement state machine for selective printing**: Added a buffering mechanism with prefix detection to print only the thinking content in real-time
     - Prints thinking content as it streams in
     - Detects action markers (`finish(message=` and `do(action=`) using prefix matching
     - Stops printing when entering the action phase while continuing to collect the full response
     - Handles edge cases where markers may arrive across multiple chunks

   ### Agent (`phone_agent/agent.py`)
   - **Move thinking header before streaming**: Relocated the thinking section header to display before model request
   - **Remove redundant thinking print**: Removed duplicate printing of `response.thinking` since it's now printed during streaming

   ## Benefits

   - **Immediate feedback**: Users can see the model's reasoning process in real-time instead of waiting for the complete response
   - **Better UX**: Provides a more interactive experience similar to ChatGPT's streaming interface
   - **No information loss**: Full response content is still preserved for parsing and action execution

   ## Technical Details

   The implementation uses a finite state machine approach:
   1. Buffer incoming chunks of content
   2. Check if buffer ends with a prefix of action markers (e.g., `"fini"` could be start of `"finish(message="`)
   3. If it's a potential prefix, hold the buffer and wait for more content
   4. If not a prefix, safely print the buffer
   5. Once a complete marker is detected, stop printing but continue collecting remaining content