### PR TITLE
replace eval with ast

### DIFF
--- a/phone_agent/actions/handler.py
+++ b/phone_agent/actions/handler.py
@@ -1,5 +1,7 @@
 """Action handler for processing AI model outputs."""
 
+import ast
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -279,10 +281,26 @@ def parse_action(response: str) -> dict[str, Any]:
         ValueError: If the response cannot be parsed.
     """
     try:
-        # Try to evaluate as Python dict/function call
         response = response.strip()
         if response.startswith("do"):
-            action = eval(response)
+            # Use AST parsing instead of eval for safety
+            try:
+                tree = ast.parse(response, mode='eval')
+                if not isinstance(tree.body, ast.Call):
+                    raise ValueError("Expected a function call")
+
+                call = tree.body
+                # Extract keyword arguments safely
+                action = {"_metadata": "do"}
+                for keyword in call.keywords:
+                    key = keyword.arg
+                    value = ast.literal_eval(keyword.value)
+                    action[key] = value
+
+                return action
+            except (SyntaxError, ValueError) as e:
+                raise ValueError(f"Failed to parse do() action: {e}")
+
         elif response.startswith("finish"):
             action = {
                 "_metadata": "finish",


### PR DESCRIPTION
   ## Security Issue

   The previous implementation used `eval()` to parse `do()` function calls from model responses:

   ```python
   if response.startswith("do"):
       action = eval(response)  # Unsafe!
   ```

   This creates a **critical security vulnerability** where malicious input could execute arbitrary Python code:

   ```python
   do(__import__('os').system('rm -rf /'))  # Code injection!
   ```

   ## Solution

   Replace `eval()` with safe AST parsing using Python's `ast` module:

   1. **Parse syntax without execution**: Use `ast.parse()` to build an AST without executing code
   2. **Extract arguments safely**: Use `ast.literal_eval()` to evaluate only literal values (strings, numbers, lists, dicts)
   3. **Validate structure**: Ensure the parsed structure is a function call with the expected format

   ## Changes

   ### `phone_agent/actions/handler.py`

   - Added `ast` import for safe parsing
   - Replaced `eval(response)` with AST-based parsing in `parse_action()`
   - Added explicit error handling for parsing failures
   - Maintained backward compatibility with existing response format

   ## Benefits

   - **Eliminates code injection risk**: Cannot execute arbitrary code
   - **Type safety**: Only accepts literal values (no function calls, imports, etc.)
   - **Better error messages**: More specific parsing error information
   - **No functional changes**: Behavior remains the same for valid inputs

   ## Testing

   The change is transparent to valid `do()` calls:

   ```python
   # These still work exactly as before
   do(action="Tap", element=[500, 300])
   do(action="Type", text="hello")
   do(action="Launch", app="微信")
   ```

   But malicious code is now rejected:

   ```python
   # These are blocked
   do(action=__import__('os'))  # ValueError
   do(action=exec('...'))        # ValueError
   ```