### PR TITLE
fix(adb): handle non-UTF8 adb output in get_current_app

### DIFF
--- a/phone_agent/adb/device.py
+++ b/phone_agent/adb/device.py
@@ -22,7 +22,11 @@ def get_current_app(device_id: str | None = None) -> str:
     adb_prefix = _get_adb_prefix(device_id)
 
     result = subprocess.run(
-        adb_prefix + ["shell", "dumpsys", "window"], capture_output=True, text=True
+        adb_prefix + ["shell", "dumpsys", "window"],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        text=True,
     )
     output = result.stdout
 


### PR DESCRIPTION
This PR updates `phone_agent/adb/device.py` to use `encoding="utf-8"` and `errors="replace"` when running `adb shell dumpsys window` in `get_current_app()`. Some devices produce non-UTF8 characters which may cause decoding errors. By explicitly setting encoding and replacing invalid bytes, we ensure robust parsing of the window focus, improving stability across diverse Android ROMs.

- Changes: add `encoding="utf-8"`, `errors="replace"`, keep `text=True`
- Scope: only affects `get_current_app()` function
- Impact: prevents UnicodeDecodeError on malformed ADB output; no behavior change for valid outputs

Base: `main`
Head: `Cznorth:fix/adb-encoding-dumpsys`