### PR TITLE
fix adb multiline input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_install_hook_types:
   - pre-commit
   - commit-msg
-
+exclude: '^phone_agent/config/apps\.py$'
 default_stages:
   - pre-commit # Run locally
 repos:

--- a/phone_agent/actions/handler.py
+++ b/phone_agent/actions/handler.py
@@ -283,7 +283,13 @@ def parse_action(response: str) -> dict[str, Any]:
     """
     try:
         response = response.strip()
-        if response.startswith("do"):
+        if response.startswith('do(action="Type"') or response.startswith(
+            'do(action="Type_Name"'
+        ):
+            text = response.split("text=", 1)[1][1:-2]
+            action = {"_metadata": "do", "action": "Type", "text": text}
+            return action
+        elif response.startswith("do"):
             # Use AST parsing instead of eval for safety
             try:
                 tree = ast.parse(response, mode="eval")


### PR DESCRIPTION
## Summary
   - Fixed parsing issue when handling Type/Type_Name actions with multiline text or special characters
   - Added special handling for Type actions that bypasses AST parsing to extract text directly
   - Excluded `phone_agent/config/apps.py` from pre-commit hooks to prevent formatting conflicts

   ## Changes
   - Modified `parse_action()` in `phone_agent/actions/handler.py` to detect Type/Type_Name actions and extract text using simple string splitting instead of AST parsing
   - This prevents parsing failures when text contains newlines, quotes, or other characters that break AST parsing
   - Updated `.pre-commit-config.yaml` to exclude auto-generated apps config file

   ## Test plan
   - [ ] Test typing single-line text
   - [ ] Test typing multiline text with newlines
   - [ ] Test typing text with special characters (quotes, backslashes, etc.)
   - [ ] Verify existing AST parsing still works for other action types
   - [ ] Run pre-commit hooks and verify apps.py is excluded