### PR TITLE
fix: add errors='ignore' to subprocess encoding for Windows compatibility

### DIFF
--- a/phone_agent/adb/device.py
+++ b/phone_agent/adb/device.py
@@ -22,7 +22,7 @@ def get_current_app(device_id: str | None = None) -> str:
     adb_prefix = _get_adb_prefix(device_id)
 
     result = subprocess.run(
-        adb_prefix + ["shell", "dumpsys", "window"], capture_output=True, text=True, encoding="utf-8"
+        adb_prefix + ["shell", "dumpsys", "window"], capture_output=True, text=True, encoding="utf-8", errors="ignore"
     )
     output = result.stdout
     if not output:

--- a/tests/test_device_encoding.py
+++ b/tests/test_device_encoding.py
@@ -1,0 +1,50 @@
+"""Tests for device.py encoding handling.
+
+This test verifies that subprocess.run is called with proper encoding parameters
+to handle Windows GBK/UTF-8 encoding issues (Issue #241).
+"""
+
+import os
+import re
+import unittest
+
+
+class TestDeviceEncodingFix(unittest.TestCase):
+    """Test that device.py has proper encoding parameters."""
+
+    def test_device_py_has_encoding_and_errors_params(self):
+        """Verify device.py uses encoding='utf-8' and errors='ignore'."""
+        device_py_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'phone_agent', 'adb', 'device.py'
+        )
+
+        with open(device_py_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        # Check for subprocess.run call with dumpsys window
+        dumpsys_pattern = r'subprocess\.run\([^)]*dumpsys.*?window[^)]*\)'
+        match = re.search(dumpsys_pattern, content, re.DOTALL)
+        self.assertIsNotNone(match, "Could not find subprocess.run with dumpsys window")
+
+        subprocess_call = match.group(0)
+
+        # Verify encoding parameter
+        self.assertIn('encoding="utf-8"', subprocess_call,
+                      "Missing encoding='utf-8' parameter")
+
+        # Verify errors parameter (key fix for Issue #241)
+        self.assertIn('errors="ignore"', subprocess_call,
+                      "Missing errors='ignore' parameter for Windows GBK/UTF-8 compatibility")
+
+        # Verify text=True is present
+        self.assertIn('text=True', subprocess_call,
+                      "Missing text=True parameter")
+
+        # Verify capture_output=True is present
+        self.assertIn('capture_output=True', subprocess_call,
+                      "Missing capture_output=True parameter")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `errors='ignore'` parameter to `subprocess.run()` in `get_current_app()` function
- Fixes Windows GBK/UTF-8 encoding conflict when reading ADB output
- Add test to verify encoding parameters

## Problem

On Windows systems, ADB output may contain mixed encoding characters that cause:
```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xb4 in position 70: illegal multibyte sequence
```

## Solution

Add `errors='ignore'` to the `subprocess.run()` call to gracefully handle encoding issues.

Fixes #241