### PR TITLE
fix: add readline import for arrow key navigation in interactive mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,12 @@ import subprocess
 import sys
 from urllib.parse import urlparse
 
+# Enable readline support for arrow key navigation in interactive mode
+try:
+    import readline  # noqa: F401
+except ImportError:
+    pass  # readline not available on Windows by default
+
 from openai import OpenAI
 
 from phone_agent import PhoneAgent

--- a/tests/test_readline_support.py
+++ b/tests/test_readline_support.py
@@ -1,0 +1,47 @@
+"""Tests for readline support in interactive mode.
+
+This test verifies that main.py imports readline to enable arrow key
+navigation and history browsing in interactive mode (Issue #223).
+"""
+
+import os
+import re
+import unittest
+
+
+class TestReadlineSupport(unittest.TestCase):
+    """Test that main.py has readline import for arrow key support."""
+
+    def test_main_py_imports_readline(self):
+        """Verify main.py imports readline module."""
+        main_py_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'main.py'
+        )
+
+        with open(main_py_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        # Check for readline import (with try/except for cross-platform compatibility)
+        self.assertIn('import readline', content,
+                      "main.py should import readline for arrow key support")
+
+    def test_readline_import_has_error_handling(self):
+        """Verify readline import has try/except for Windows compatibility."""
+        main_py_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'main.py'
+        )
+
+        with open(main_py_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        # Check that readline import is wrapped in try/except
+        pattern = r'try:\s*\n\s*import readline.*?\nexcept ImportError:'
+        match = re.search(pattern, content, re.DOTALL)
+        self.assertIsNotNone(match,
+                             "readline import should be wrapped in try/except for Windows compatibility")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `import readline` to main.py for arrow key support in interactive mode
- Wrap import in try/except for Windows compatibility
- Add tests to verify readline import

## Problem

In interactive mode, arrow keys produce escape sequences (`^[[A`, `^[[B`, etc.) instead of navigating or browsing command history.

## Solution

Import the readline module which provides proper terminal input handling. The import is wrapped in try/except since readline may not be available on Windows by default.

Fixes #223