### PR TITLE
fix issue #297: UnicodeEncodeError in date formatting for non-Chinese locale systems (issu

### DIFF
--- a/phone_agent/config/prompts.py
+++ b/phone_agent/config/prompts.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 
 today = datetime.today()
-formatted_date = today.strftime("%Y年%m月%d日")
+formatted_date = f"{today.year}年{today.month:02d}月{today.day:02d}日"
 
 SYSTEM_PROMPT = (
     "今天的日期是: "

--- a/phone_agent/config/prompts_zh.py
+++ b/phone_agent/config/prompts_zh.py
@@ -5,7 +5,7 @@ from datetime import datetime
 today = datetime.today()
 weekday_names = ["星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日"]
 weekday = weekday_names[today.weekday()]
-formatted_date = today.strftime("%Y年%m月%d日") + " " + weekday
+formatted_date = f"{today.year}年{today.month:02d}月{today.day:02d}日 {weekday}"
 
 SYSTEM_PROMPT = (
     "今天的日期是: "


### PR DESCRIPTION
fixes issue #297 

**Problem:**
Running the application on systems with non-Chinese locales causes a UnicodeEncodeError during import. The application crashes immediately on startup before any functionality can be used. The strftime() function uses the system's locale encoding to process the format string. On systems without Chinese locale support (e.g., cp1252 on German Windows), the characters 年, 月, 日 cannot be encoded.

**Error Message:**
`File "...\phone_agent\config\prompts_zh.py", line 8, in <module>
    formatted_date = today.strftime("%Y年%m月%d日") + " " + weekday
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'locale' codec can't encode character '\u5e74' in position 2: encoding error`

**Fix:**

Replaced strftime() with f-string formatting to avoid locale-dependent encoding

Changes:

old: 
`formatted_date = today.strftime("%Y年%m月%d日") + " " + weekday`
.
.
.
new:
`formatted_date = f"{today.year}年{today.month:02d}月{today.day:02d}日 {weekday}"`

