### PR TITLE
修复parse_action函数：移除</answer>标签导致的语法解析错误

### DIFF
--- a/phone_agent/actions/handler.py
+++ b/phone_agent/actions/handler.py
@@ -358,6 +358,8 @@ def parse_action(response: str) -> dict[str, Any]:
                 response = response.replace('\n', '\\n')
                 response = response.replace('\r', '\\r')
                 response = response.replace('\t', '\\t')
+                response = response.replace("</answer>", "")
+                response = response.replace("<answer>", "")
 
                 tree = ast.parse(response, mode="eval")
                 if not isinstance(tree.body, ast.Call):


### PR DESCRIPTION
### 问题描述（Problem Description）
使用 Open-AutoGLM 操作手机时，parse_action 函数解析 LLM 返回的动作指令（如 do(action="Tap", element=[811,188])）时，因指令字符串中混入  非 Python 语法标签，导致 ast.parse 解析失败，抛出 SyntaxError 异常，进而触发 ValueError 报错，无法正常执行点击等操作。

相关报错日志：
```Parsing action: do(action="Tap", element=[811,188])</answer>
Traceback (most recent call last):
  File "/Users/rich/repos/Open-AutoGLM/phone_agent/actions/handler.py", line 362, in parse_action
    tree = ast.parse(response, mode="eval")
  File "/Users/rich/miniconda3/envs/autoglm/lib/python3.10/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 1
    do(action="Tap", element=[811,188])</answer>
                                        ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/rich/repos/Open-AutoGLM/phone_agent/actions/handler.py", line 376, in parse_action
    raise ValueError(f"Failed to parse do() action: {e}")
ValueError: Failed to parse do() action: invalid syntax (<unknown>, line 1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/rich/repos/Open-AutoGLM/phone_agent/agent.py", line 191, in _execute_step
    action = parse_action(response.action)
  File "/Users/rich/repos/Open-AutoGLM/phone_agent/actions/handler.py", line 387, in parse_action
    raise ValueError(f"Failed to parse action: {e}")
ValueError: Failed to parse action: Failed to parse do() action: invalid syntax (<unknown>, line 1)
```
### 解决方案（Solution）
在 phone_agent/actions/handler.py 的 parse_action 函数中，新增字符串清理逻辑，解析前先处理无关字符：
```Python
                response = response.replace("</answer>", "")
                response = response.replace("<answer>", "")

                tree = ast.parse(response, mode="eval")
```