### PR TITLE
fix: resolve duplicate phrase and typo in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ python3 -m sglang.launch_server --model-path  zai-org/AutoGLM-Phone-9B \
         --port 8000
 ```
 
-- 该模型结构与 `GLM-4.1V-9B-Thinking` 相同, 关于模型部署的详细内容，你也以查看 [GLM-V](https://github.com/zai-org/GLM-V)
+- 该模型结构与 `GLM-4.1V-9B-Thinking` 相同, 关于模型部署的详细内容，你也可以查看 [GLM-V](https://github.com/zai-org/GLM-V)
   获取模型部署和使用指南。
 
 - 运行成功后，将可以通过 `http://localhost:8000/v1` 访问模型服务。 如果您在远程服务器部署模型, 使用该服务器的IP访问模型.

--- a/README_en.md
+++ b/README_en.md
@@ -207,7 +207,7 @@ python3 -m vllm.entrypoints.openai.api_server \
  --port 8000
 ```
 
-- This model has the same architecture as `GLM-4.1V-9B-Thinking`. For detailed information about model deployment, you can also check [GLM-V](https://github.com/zai-org/GLM-V) for model deployment and usage guides.
+- This model has the same architecture as `GLM-4.1V-9B-Thinking`. For detailed information about model deployment, you can also check [GLM-V](https://github.com/zai-org/GLM-V) for usage guides.
 
 - After successful startup, the model service will be accessible at `http://localhost:8000/v1`. If you deploy the model on a remote server, access it using that server's IP address.
 


### PR DESCRIPTION
## Summary

Fixed two minor issues in the README documentation:

1. **README.md**: Fixed typo - "你也以查看" → "你也可以查看"
2. **README_en.md**: Removed duplicate phrase "model deployment" 

## Changes

- `README.md`: Line 258 - Fixed Chinese typo
- `README_en.md`: Line 210 - Removed redundant phrase

## Testing

- [x] Documentation renders correctly
- [x] No breaking changes