### PR TITLE
fix(adb): improve iQOO12 Pro stability with dumpsys fallbacks, device binding, and screenshot fallback hardening

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,9 @@ from phone_agent.xctest import list_devices as list_ios_devices
 
 
 def check_system_requirements(
-    device_type: DeviceType = DeviceType.ADB, wda_url: str = "http://localhost:8100"
+    device_type: DeviceType = DeviceType.ADB,
+    wda_url: str = "http://localhost:8100",
+    device_id: str | None = None,
 ) -> bool:
     """
     Check system requirements before running the agent.
@@ -195,8 +197,11 @@ def check_system_requirements(
     if device_type == DeviceType.ADB:
         print("3. Checking ADB Keyboard...", end=" ")
         try:
+            adb_cmd = ["adb"]
+            if device_id:
+                adb_cmd.extend(["-s", device_id])
             result = subprocess.run(
-                ["adb", "shell", "ime", "list", "-s"],
+                adb_cmd + ["shell", "ime", "list", "-s"],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -267,6 +272,24 @@ def check_system_requirements(
         print("❌ System check failed. Please fix the issues above.")
 
     return all_passed
+
+
+def auto_select_adb_device_id() -> str | None:
+    """Auto-select the first healthy ADB device."""
+    try:
+        result = subprocess.run(
+            ["adb", "devices"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=5,
+        )
+        for line in result.stdout.splitlines()[1:]:
+            if "\tdevice" in line:
+                return line.split("\t", 1)[0].strip()
+    except Exception:
+        return None
+    return None
 
 
 def check_model_api(base_url: str, model_name: str, api_key: str = "EMPTY") -> bool:
@@ -731,12 +754,20 @@ def main():
     if handle_device_commands(args):
         return
 
+    # Auto-select a healthy ADB device if not explicitly specified.
+    if device_type == DeviceType.ADB and not args.device_id:
+        auto_device_id = auto_select_adb_device_id()
+        if auto_device_id:
+            args.device_id = auto_device_id
+            print(f"Auto-selected ADB device: {args.device_id}")
+
     # Run system requirements check before proceeding
     if not check_system_requirements(
         device_type,
         wda_url=args.wda_url
         if device_type == DeviceType.IOS
         else "http://localhost:8100",
+        device_id=args.device_id if device_type == DeviceType.ADB else None,
     ):
         sys.exit(1)
 

--- a/phone_agent/adb/device.py
+++ b/phone_agent/adb/device.py
@@ -21,21 +21,60 @@ def get_current_app(device_id: str | None = None) -> str:
     """
     adb_prefix = _get_adb_prefix(device_id)
 
-    result = subprocess.run(
-        adb_prefix + ["shell", "dumpsys", "window"], capture_output=True, text=True, encoding="utf-8"
+    # Different Android builds expose focus info in different dumpsys subcommands.
+    focus_commands = [
+        ["shell", "dumpsys", "window", "displays"],
+        ["shell", "dumpsys", "window", "windows"],
+        ["shell", "dumpsys", "window"],
+        ["shell", "dumpsys", "activity", "activities"],
+        ["shell", "dumpsys", "activity", "top"],
+    ]
+    focus_markers = (
+        "mCurrentFocus",
+        "mFocusedApp",
+        "mResumedActivity",
+        "topResumedActivity",
     )
-    output = result.stdout
-    if not output:
-        raise ValueError("No output from dumpsys window")
 
-    # Parse window focus info
-    for line in output.split("\n"):
-        if "mCurrentFocus" in line or "mFocusedApp" in line:
-            for app_name, package in APP_PACKAGES.items():
-                if package in line:
-                    return app_name
+    diagnostics: list[str] = []
+    has_any_output = False
 
-    return "System Home"
+    for cmd in focus_commands:
+        result = subprocess.run(
+            adb_prefix + cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        stdout = result.stdout or ""
+        stderr = (result.stderr or "").strip()
+
+        if not stdout.strip():
+            if result.returncode != 0 or stderr:
+                diagnostics.append(
+                    f"{' '.join(cmd)} failed (code={result.returncode}): {stderr or 'no stderr'}"
+                )
+            continue
+
+        has_any_output = True
+
+        # Prefer lines that explicitly contain focus markers.
+        for line in stdout.splitlines():
+            if any(marker in line for marker in focus_markers):
+                for app_name, package in APP_PACKAGES.items():
+                    if package in line:
+                        return app_name
+
+        # Fallback: match package anywhere in command output.
+        for app_name, package in APP_PACKAGES.items():
+            if package in stdout:
+                return app_name
+
+    if has_any_output:
+        return "System Home"
+
+    summary = "; ".join(diagnostics[:3]) if diagnostics else "all dumpsys commands returned empty output"
+    raise ValueError(f"Unable to get current app: {summary}")
 
 
 def tap(
@@ -249,4 +288,25 @@ def _get_adb_prefix(device_id: str | None) -> list:
     """Get ADB command prefix with optional device specifier."""
     if device_id:
         return ["adb", "-s", device_id]
+    auto_device_id = _auto_select_device_id()
+    if auto_device_id:
+        return ["adb", "-s", auto_device_id]
     return ["adb"]
+
+
+def _auto_select_device_id() -> str | None:
+    """Select the first healthy ADB device when device_id is not provided."""
+    try:
+        result = subprocess.run(
+            ["adb", "devices"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=5,
+        )
+        for line in result.stdout.splitlines()[1:]:
+            if "\tdevice" in line:
+                return line.split("\t", 1)[0].strip()
+    except Exception:
+        return None
+    return None

--- a/phone_agent/adb/input.py
+++ b/phone_agent/adb/input.py
@@ -106,4 +106,25 @@ def _get_adb_prefix(device_id: str | None) -> list:
     """Get ADB command prefix with optional device specifier."""
     if device_id:
         return ["adb", "-s", device_id]
+    auto_device_id = _auto_select_device_id()
+    if auto_device_id:
+        return ["adb", "-s", auto_device_id]
     return ["adb"]
+
+
+def _auto_select_device_id() -> str | None:
+    """Select the first healthy ADB device when device_id is not provided."""
+    try:
+        result = subprocess.run(
+            ["adb", "devices"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=5,
+        )
+        for line in result.stdout.splitlines()[1:]:
+            if "\tdevice" in line:
+                return line.split("\t", 1)[0].strip()
+    except Exception:
+        return None
+    return None

--- a/phone_agent/adb/screenshot.py
+++ b/phone_agent/adb/screenshot.py
@@ -49,9 +49,19 @@ def get_screenshot(device_id: str | None = None, timeout: int = 10) -> Screensho
             timeout=timeout,
         )
 
-        # Check for screenshot failure (sensitive screen)
+        # Check for screenshot failure due to sensitive/secure screens.
+        # Generic command failures (e.g., transport/device selection issues)
+        # should not be treated as sensitive screens.
         output = result.stdout + result.stderr
-        if "Status: -1" in output or "Failed" in output:
+        output_lower = output.lower()
+        if result.returncode != 0:
+            return _create_fallback_screenshot(is_sensitive=False)
+        if (
+            "status: -1" in output_lower
+            or "sensitive screen" in output_lower
+            or "secure screen" in output_lower
+            or "security" in output_lower
+        ):
             return _create_fallback_screenshot(is_sensitive=True)
 
         # Pull screenshot to local temp path
@@ -89,7 +99,28 @@ def _get_adb_prefix(device_id: str | None) -> list:
     """Get ADB command prefix with optional device specifier."""
     if device_id:
         return ["adb", "-s", device_id]
+    auto_device_id = _auto_select_device_id()
+    if auto_device_id:
+        return ["adb", "-s", auto_device_id]
     return ["adb"]
+
+
+def _auto_select_device_id() -> str | None:
+    """Select the first healthy ADB device when device_id is not provided."""
+    try:
+        result = subprocess.run(
+            ["adb", "devices"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=5,
+        )
+        for line in result.stdout.splitlines()[1:]:
+            if "\tdevice" in line:
+                return line.split("\t", 1)[0].strip()
+    except Exception:
+        return None
+    return None
 
 
 def _create_fallback_screenshot(is_sensitive: bool) -> Screenshot:


### PR DESCRIPTION
## 背景
在 vivo iQOO 12 Pro（Android/OriginOS）上执行任务（如“打开设置，然后停止”）时，出现不稳定中断。

## 设备环境
- 机型：vivo iQOO 12 Pro
- 连接方式：ADB（USB/Wi-Fi）
- 场景：系统设置页、系统小窗/侧边栏等界面

## 问题现象
1. `dumpsys window` 单命令无法稳定拿到焦点 app。
2. 偶发 `adb: more than one device/emulator`，导致任务中断。
3. 截图失败时回退黑图，LLM 误判为“敏感页面”，触发不必要 `Take_over`。

## 根因分析
1. 不同 ROM/系统界面（尤其小窗、侧边栏）会改变焦点信息所在的 `dumpsys` 子命令输出，单一路径不可靠。
2. 未显式绑定 `device_id` 时，ADB 在多 transport 场景天然不稳定。
3. 截图失败被过度归类为敏感屏，放大了上游 ADB 异常的影响。

## 修复内容
1. 为当前 app 检测增加多级 fallback：`dumpsys window displays -> window windows -> window -> activity activities -> activity top`。
2. 在未传 `--device-id` 时自动选择首个健康设备（`status=device`），并在系统检查阶段也使用该设备。
3. 截图失败改为“通用失败”与“敏感屏”分流，只有明确安全拦截特征才标记敏感。
4. 错误信息增加 `returncode/stderr`，便于快速诊断。

## 验证建议
1. `python main.py --device-id <real_device_id> "打开设置，然后停止"`
2. 在 iQOO 12 Pro 上进入系统设置/小窗侧边栏场景重复执行。
3. 同时保留模拟器或远程设备，确认不再出现 `more than one device/emulator` 中断。
4. 人为制造一次截图失败，确认不再被误判成敏感页接管。
