### PR TITLE
fix: Android 13+ compatibility for ADB Keyboard check

### DIFF
--- a/main.py
+++ b/main.py
@@ -203,7 +203,31 @@ def check_system_requirements(
             )
             ime_list = result.stdout.strip()
 
-            if "com.android.adbkeyboard/.AdbIME" in ime_list:
+            # Check if permission denied (Android 13+)
+            if "SecurityException" in result.stderr or "Permission" in result.stderr:
+                # Fallback: check if package is installed
+                pkg_result = subprocess.run(
+                    [
+                        "adb",
+                        "shell",
+                        "pm",
+                        "list",
+                        "packages",
+                        "com.android.adbkeyboard",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if "com.android.adbkeyboard" in pkg_result.stdout:
+                    print(
+                        "✅ OK (package installed, please ensure enabled in settings)"
+                    )
+                else:
+                    print("❌ FAILED")
+                    print("   Error: ADB Keyboard is not installed on the device.")
+                    all_passed = False
+            elif "com.android.adbkeyboard/.AdbIME" in ime_list:
                 print("✅ OK")
             else:
                 print("❌ FAILED")


### PR DESCRIPTION
- Fallback to check package installation when ime list fails due to permission restrictions (SecurityException on Android 13+)

# Contribution Guide

We welcome your contributions to this repository. To ensure elegant code style and better code quality, we have prepared
the following contribution guidelines.

## What We Accept

+ This PR fixes a typo or improves the documentation (if this is the case, you may skip the other checks).
+ This PR fixes a specific issue — please reference the issue number in the PR description. Make sure your code strictly
  follows the coding standards below.
+ This PR introduces a new feature — please clearly explain the necessity and implementation of the feature. Make sure
  your code strictly follows the coding standards below.

## Code Style Guide

Good code style is an art. We have prepared a `pre-commit` hook to enforce consistent code
formatting across the project. You can clean up your code following the steps below:

```shell
pre-commit run --all-files
```

If your code complies with the standards, you should not see any errors.

## Naming Conventions

+ Please use **English** for naming; do not use Pinyin or other languages. All comments should also be in English.
+ Follow **PEP8** naming conventions strictly, and use underscores to separate words. Avoid meaningless names such as
  `a`, `b`, `c`.

## For glmv-reward Contributors

Before PR, Please run:

```bash
cd glmv-reward/
uv sync
uv run poe lint
uv run poe typecheck
```
