### PR TITLE
fix: allow sglang-pinned OpenAI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow>=12.0.0
-openai>=2.9.0
+openai>=2.6.1
 
 # For iOS Support
 requests>=2.31.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "Pillow>=12.0.0",
-        "openai>=2.9.0",
+        "openai>=2.6.1",
     ],
     extras_require={
         "dev": [

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -1,0 +1,36 @@
+import ast
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SGLANG_PINNED_OPENAI_VERSION = Version("2.6.1")
+
+
+def _openai_requirement_from_requirements_txt() -> Requirement:
+    requirements_path = PROJECT_ROOT / "requirements.txt"
+    for line in requirements_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("openai"):
+            return Requirement(stripped)
+    raise AssertionError("requirements.txt does not declare openai")
+
+
+def _openai_requirement_from_setup_py() -> Requirement:
+    setup_tree = ast.parse((PROJECT_ROOT / "setup.py").read_text(encoding="utf-8"))
+    for node in ast.walk(setup_tree):
+        if isinstance(node, ast.keyword) and node.arg == "install_requires":
+            requirements = ast.literal_eval(node.value)
+            for requirement in requirements:
+                if requirement.startswith("openai"):
+                    return Requirement(requirement)
+    raise AssertionError("setup.py does not declare openai")
+
+
+def test_openai_dependency_allows_sglang_pinned_version() -> None:
+    for requirement in (
+        _openai_requirement_from_requirements_txt(),
+        _openai_requirement_from_setup_py(),
+    ):
+        assert SGLANG_PINNED_OPENAI_VERSION in requirement.specifier


### PR DESCRIPTION
## Summary

- Fixes #302 by relaxing the OpenAI dependency lower bound from `>=2.9.0` to `>=2.6.1` in both `requirements.txt` and `setup.py`.
- Keeps the package metadata and requirements file aligned.
- Adds a regression test that ensures the dependency spec allows the `openai==2.6.1` version pinned by `sglang 0.5.6.post1/post2`.

## Test Plan

- [x] python -m pytest
- [x] pre-commit run --files requirements.txt setup.py tests/test_dependency_constraints.py
- [x] /tmp/open-autoglm-openai-261/bin/python -m pip install 'openai==2.6.1' 'Pillow>=12.0.0' 'requests>=2.31.0'
- [x] /tmp/open-autoglm-openai-261/bin/python -m pip install -e . --no-deps
- [x] Verified installed `phone-agent` metadata reports `openai>=2.6.1` with `openai` version `2.6.1`
