### PR TITLE
fix: target ADB Keyboard broadcasts explicitly

### DIFF
--- a/phone_agent/adb/input.py
+++ b/phone_agent/adb/input.py
@@ -4,6 +4,8 @@ import base64
 import subprocess
 from typing import Optional
 
+ADB_KEYBOARD_PACKAGE = "com.android.adbkeyboard"
+
 
 def type_text(text: str, device_id: str | None = None) -> None:
     """
@@ -31,6 +33,8 @@ def type_text(text: str, device_id: str | None = None) -> None:
             "--es",
             "msg",
             encoded_text,
+            "-p",
+            ADB_KEYBOARD_PACKAGE,
         ],
         capture_output=True,
         text=True,
@@ -47,7 +51,16 @@ def clear_text(device_id: str | None = None) -> None:
     adb_prefix = _get_adb_prefix(device_id)
 
     subprocess.run(
-        adb_prefix + ["shell", "am", "broadcast", "-a", "ADB_CLEAR_TEXT"],
+        adb_prefix
+        + [
+            "shell",
+            "am",
+            "broadcast",
+            "-a",
+            "ADB_CLEAR_TEXT",
+            "-p",
+            ADB_KEYBOARD_PACKAGE,
+        ],
         capture_output=True,
         text=True,
     )

--- a/tests/test_adb_input.py
+++ b/tests/test_adb_input.py
@@ -1,0 +1,35 @@
+import subprocess
+
+from phone_agent.adb import input as adb_input
+
+
+def test_type_text_targets_adb_keyboard_package(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_run)
+
+    adb_input.type_text("你好", device_id="device-1")
+
+    command = commands[0]
+    assert command[:3] == ["adb", "-s", "device-1"]
+    assert command[-2:] == ["-p", "com.android.adbkeyboard"]
+
+
+def test_clear_text_targets_adb_keyboard_package(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(adb_input.subprocess, "run", fake_run)
+
+    adb_input.clear_text(device_id="device-1")
+
+    command = commands[0]
+    assert command[:3] == ["adb", "-s", "device-1"]
+    assert command[-2:] == ["-p", "com.android.adbkeyboard"]


### PR DESCRIPTION
## Summary

- Fixes #180 by adding `-p com.android.adbkeyboard` to ADB Keyboard broadcasts.
- Targets both `ADB_INPUT_B64` and `ADB_CLEAR_TEXT` so Android versions that block implicit broadcasts can still deliver text input commands to ADB Keyboard.
- Adds regression tests for the generated ADB commands with `--device-id`.

## Test Plan

- [x] python -m pytest
- [x] pre-commit run --files phone_agent/adb/input.py tests/test_adb_input.py
