### PR TITLE
fix: guard against empty choices and message=None in deployment checks

### DIFF
--- a/scripts/check_deployment_cn.py
+++ b/scripts/check_deployment_cn.py
@@ -94,6 +94,8 @@ if __name__ == "__main__":
 
         print("\n模型推理结果:")
         print("=" * 80)
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         print(response.choices[0].message.content)
         print("=" * 80)
 

--- a/scripts/check_deployment_en.py
+++ b/scripts/check_deployment_en.py
@@ -106,6 +106,8 @@ Usage examples:
 
         print("\nModel inference result:")
         print("=" * 80)
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         print(response.choices[0].message.content)
         print("=" * 80)
 


### PR DESCRIPTION
## Problem

Both `scripts/check_deployment_cn.py` and `scripts/check_deployment_en.py` print `response.choices[0].message.content` without checking if `choices` is empty or `message` is `None`.

This causes `IndexError` or `AttributeError` instead of a meaningful error during deployment validation.

## Fix

Adds the guard before each access:

```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```

**4 lines added, 0 deleted.**

Detected by [pact](https://github.com/qizwiz/pact) static analysis.