### PR TITLE
fix: handle bare numeric and negative durations in Wait action handler

### DIFF
--- a/phone_agent/actions/handler.py
+++ b/phone_agent/actions/handler.py
@@ -1,6 +1,7 @@
 """Action handler for processing AI model outputs."""
 
 import ast
+import math
 import re
 import subprocess
 import time
@@ -237,8 +238,10 @@ class ActionHandler:
         except (ValueError, TypeError):
             duration = 1.0
 
-        # ``time.sleep`` raises ``ValueError`` for negative values, so clamp.
-        if duration < 0:
+        # ``time.sleep`` accepts ``float('nan')`` and ``float('inf')`` as valid
+        # arguments, but neither is useful here: NaN produces no wait and inf
+        # would hang the agent. Clamp non-finite values to the default.
+        if duration < 0 or not math.isfinite(duration):
             duration = 1.0
 
         time.sleep(duration)

--- a/phone_agent/actions/handler.py
+++ b/phone_agent/actions/handler.py
@@ -223,10 +223,22 @@ class ActionHandler:
 
     def _handle_wait(self, action: dict, width: int, height: int) -> ActionResult:
         """Handle wait action."""
-        duration_str = action.get("duration", "1 seconds")
+        duration_raw = action.get("duration", "1 seconds")
         try:
-            duration = float(duration_str.replace("seconds", "").strip())
-        except ValueError:
+            # The model normally emits a string such as "3 seconds", but some
+            # models (or non-standard prompts) return a bare int/float instead.
+            # Calling ``.replace`` on a number raises ``AttributeError``, which
+            # the previous ``except ValueError`` did not catch, so the wait
+            # silently failed. Handle both forms explicitly.
+            if isinstance(duration_raw, (int, float)):
+                duration = float(duration_raw)
+            else:
+                duration = float(str(duration_raw).replace("seconds", "").strip())
+        except (ValueError, TypeError):
+            duration = 1.0
+
+        # ``time.sleep`` raises ``ValueError`` for negative values, so clamp.
+        if duration < 0:
             duration = 1.0
 
         time.sleep(duration)

--- a/tests/test_wait_action.py
+++ b/tests/test_wait_action.py
@@ -1,0 +1,77 @@
+"""Unit tests for the ``Wait`` action handler.
+
+These tests exercise ``ActionHandler._handle_wait`` via the public ``execute``
+entry point. They are pure and deterministic — ``time.sleep`` is patched so no
+real time is spent and no device or network access is required.
+"""
+
+from unittest.mock import patch
+
+from phone_agent.actions.handler import ActionHandler
+
+
+def _wait_action(**kwargs):
+    action = {"_metadata": "do", "action": "Wait"}
+    action.update(kwargs)
+    return action
+
+
+class TestHandleWait:
+    """Tests for ``ActionHandler._handle_wait`` robustness."""
+
+    def test_string_duration_with_unit(self):
+        handler = ActionHandler()
+        with patch("phone_agent.actions.handler.time.sleep") as sleep:
+            result = handler.execute(_wait_action(duration="3 seconds"), 1080, 1920)
+        assert result.success is True
+        assert result.should_finish is False
+        sleep.assert_called_once_with(3.0)
+
+    def test_string_duration_without_unit(self):
+        handler = ActionHandler()
+        with patch("phone_agent.actions.handler.time.sleep") as sleep:
+            result = handler.execute(_wait_action(duration="2"), 1080, 1920)
+        assert result.success is True
+        sleep.assert_called_once_with(2.0)
+
+    def test_default_duration_when_missing(self):
+        handler = ActionHandler()
+        with patch("phone_agent.actions.handler.time.sleep") as sleep:
+            result = handler.execute(_wait_action(), 1080, 1920)
+        assert result.success is True
+        sleep.assert_called_once_with(1.0)
+
+    def test_integer_duration_does_not_crash(self):
+        """A bare int duration must not raise AttributeError.
+
+        Previously ``int.replace`` raised ``AttributeError`` which the
+        ``except ValueError`` clause did not catch, so the wait silently
+        failed with ``success=False``.
+        """
+        handler = ActionHandler()
+        with patch("phone_agent.actions.handler.time.sleep") as sleep:
+            result = handler.execute(_wait_action(duration=3), 1080, 1920)
+        assert result.success is True
+        sleep.assert_called_once_with(3.0)
+
+    def test_float_duration(self):
+        handler = ActionHandler()
+        with patch("phone_agent.actions.handler.time.sleep") as sleep:
+            result = handler.execute(_wait_action(duration=1.5), 1080, 1920)
+        assert result.success is True
+        sleep.assert_called_once_with(1.5)
+
+    def test_unparseable_duration_falls_back(self):
+        handler = ActionHandler()
+        with patch("phone_agent.actions.handler.time.sleep") as sleep:
+            result = handler.execute(_wait_action(duration="soon"), 1080, 1920)
+        assert result.success is True
+        sleep.assert_called_once_with(1.0)
+
+    def test_negative_duration_is_clamped(self):
+        """A negative duration must be clamped so time.sleep does not raise."""
+        handler = ActionHandler()
+        with patch("phone_agent.actions.handler.time.sleep") as sleep:
+            result = handler.execute(_wait_action(duration="-5 seconds"), 1080, 1920)
+        assert result.success is True
+        sleep.assert_called_once_with(1.0)

--- a/tests/test_wait_action.py
+++ b/tests/test_wait_action.py
@@ -75,3 +75,21 @@ class TestHandleWait:
             result = handler.execute(_wait_action(duration="-5 seconds"), 1080, 1920)
         assert result.success is True
         sleep.assert_called_once_with(1.0)
+
+    def test_non_finite_duration_falls_back(self):
+        """NaN and infinite durations must fall back to the default."""
+        handler = ActionHandler()
+        for raw in ("nan", "inf", "NaN", "+Infinity"):
+            with patch("phone_agent.actions.handler.time.sleep") as sleep:
+                result = handler.execute(_wait_action(duration=raw), 1080, 1920)
+            assert result.success is True, f"duration={raw!r} should not fail"
+            sleep.assert_called_once_with(1.0)
+            sleep.reset_mock()
+
+    def test_zero_duration_is_allowed(self):
+        """Zero is a legitimate finite duration and should not be clamped."""
+        handler = ActionHandler()
+        with patch("phone_agent.actions.handler.time.sleep") as sleep:
+            result = handler.execute(_wait_action(duration="0 seconds"), 1080, 1920)
+        assert result.success is True
+        sleep.assert_called_once_with(0.0)


### PR DESCRIPTION
## Summary

Fixes a bug in `ActionHandler._handle_wait` where the `Wait` action silently failed when the model returned a bare numeric duration (`int`/`float`) instead of a string like `"3 seconds"`.

## Root cause

`_handle_wait` always calls `.replace("seconds", "")` on `action.get("duration")`. When a model emits `do(action="Wait", duration=3)`, `ast.literal_eval` returns the integer `3`. Calling `.replace()` on an `int` raises `AttributeError`, which the `except ValueError` clause does **not** catch, so the action falls through to `execute()`'s generic handler and reports `success=False` with `Action failed: 'int' object has no attribute 'replace'` — no actual wait happens. A negative duration string (e.g. `"-5 seconds"`) is a second latent defect: it parses to `-5.0` and `time.sleep(-5.0)` raises `ValueError`.

## Fix (`phone_agent/actions/handler.py`)

- Check `isinstance(duration_raw, (int, float))` before calling string methods; convert numeric input to `float` directly.
- Broaden the exception clause to `except (ValueError, TypeError)`.
- Clamp negative durations to `1.0` so `time.sleep` cannot raise.

The documented happy path `duration="N seconds"` is unchanged.

## Test (`tests/test_wait_action.py`)

Seven deterministic tests driving `ActionHandler.execute`, covering: string with unit, string without unit, missing key (default), bare `int` (the bug), bare `float`, unparseable fallback, and negative clamp. `time.sleep` is patched — no device or network access.

## Verification

- No other open PR touches `_handle_wait` (checked #347, #394, #402, #385).
- Independent of the Type-parser IndexError fix (#394) and the malformed-action fail-on-parse change (#402); new test file name avoids collision with #410's `tests/test_handler.py`.