### PR TITLE
fix: use regex exact match in get_current_app to prevent package substring misidentification

### DIFF
--- a/phone_agent/adb/device.py
+++ b/phone_agent/adb/device.py
@@ -1,6 +1,7 @@
 """Device control utilities for Android automation."""
 
 import os
+import re
 import subprocess
 import time
 from typing import List, Optional, Tuple
@@ -31,9 +32,22 @@ def get_current_app(device_id: str | None = None) -> str:
     # Parse window focus info
     for line in output.split("\n"):
         if "mCurrentFocus" in line or "mFocusedApp" in line:
-            for app_name, package in APP_PACKAGES.items():
-                if package in line:
-                    return app_name
+            # Extract the package name from the window focus line.
+            # Format: Window{... u0 com.example.app/com.example.MainActivity}
+            # Using regex avoids false substring matches (e.g.,
+            # "com.google.android.apps.docs" incorrectly matching
+            # "com.google.android.apps.docs.editors.docs").
+            match = re.search(r"\s(\w+)\s+([\w.]+)/", line)
+            if match:
+                pkg = match.group(2)
+                for app_name, package in APP_PACKAGES.items():
+                    if package == pkg:
+                        return app_name
+            else:
+                # Fallback for unusual dumpsys formats
+                for app_name, package in APP_PACKAGES.items():
+                    if package in line:
+                        return app_name
 
     return "System Home"
 


### PR DESCRIPTION
## Problem

`phone_agent/adb/device.py` `get_current_app()` uses **substring matching** (`if package in line`) to identify the running app from `dumpsys window` output. This causes **misidentification when one package name is a substring of another**.

### Concrete example

The `APP_PACKAGES` dict contains:
- `"GoogleDrive": "com.google.android.apps.docs"` (Google Drive)
- `"Google Docs": "com.google.android.apps.docs.editors.docs"` (Google Docs)
- `"GoogleSlides": "com.google.android.apps.docs.editors.slides"` (Google Slides)

When Google Docs is running, `dumpsys window` outputs:
```
mCurrentFocus=Window{abc123 u0 com.google.android.apps.docs.editors.docs/...}
```

The substring check `"com.google.android.apps.docs" in line` evaluates to `True`, so it incorrectly returns "Google Drive" (which appears first in dict insertion order) instead of "Google Docs". The same misidentification occurs with Google Slides.

## Fix

Replace substring matching with regex-based exact package extraction followed by exact dict lookup. The regex `r"\s(\w+)\s+([\w.]+)/"` extracts the package portion from the dumpsys window format (`Window{... u0 com.example.app/...}`).

A substring-matching fallback is kept for unusual dumpsys formats where the regex may not match.

## Verification

- `python -m py_compile` passes on the changed file
- Regex tested against sample `dumpsys window` lines — correctly extracts `com.google.android.apps.docs.editors.docs` for Docs vs `com.google.android.apps.docs` for Drive