### PR TITLE
feat: support MobileForge models and Qwen3-VL-4B LoRA recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ python main.py \
 也可以设置 `PHONE_AGENT_PROFILE=mobileforge`。`mobile_use` 动作会被转换为
 AutoGLM 动作后交给所选设备后端执行。模型权重不包含在本仓库中，需要从
 [MobileForge 模型集合](https://huggingface.co/collections/lgy0404/mobileforge-models)
-单独下载和部署。
+单独下载和部署。使用 MobileForge 数据对 Qwen3-VL-4B 进行 LoRA SFT
+以及部署合并模型的可复现示例见
+[`examples/mobileforge/`](examples/mobileforge/README.md)。
 
 ### Midscene.js
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ ADB 调试能力，可通过 WiFi 或网络连接设备，实现灵活的远程�
 
 ## 与其他自动化工具集成
 
+### MobileForge 模型
+
+Open-AutoGLM 可以使用
+[MobileForge](https://github.com/kwai/MobileForge) 发布的 ForgeQwen3/ForgeOwl
+模型作为决策层，同时复用 ADB 或 HDC 设备执行层。首先通过 vLLM 等服务部署
+模型的 OpenAI 兼容接口，然后运行：
+
+```bash
+python main.py \
+  --device-type hdc \
+  --agent-profile mobileforge \
+  --base-url http://localhost:8000/v1 \
+  --model lgy0404/ForgeQwen3-8B \
+  "打开设置并查看当前系统版本"
+```
+
+也可以设置 `PHONE_AGENT_PROFILE=mobileforge`。`mobile_use` 动作会被转换为
+AutoGLM 动作后交给所选设备后端执行。模型权重不包含在本仓库中，需要从
+[MobileForge 模型集合](https://huggingface.co/collections/lgy0404/mobileforge-models)
+单独下载和部署。
+
 ### Midscene.js
 
 [Midscene.js](https://midscenejs.com/zh/index.html) 是一款由视觉模型驱动的开源 UI 自动化 SDK，支持通过 JavaScript 或 Yaml 格式的流程语法，实现多平台的自动化。

--- a/README_en.md
+++ b/README_en.md
@@ -29,6 +29,28 @@ Phone Agent is a mobile intelligent assistant framework built on AutoGLM. It und
 
 ## Integration with Other Automation Tools
 
+### MobileForge models
+
+Open-AutoGLM can use the ForgeQwen3/ForgeOwl models released by
+[MobileForge](https://github.com/kwai/MobileForge) as its decision layer while
+reusing the ADB or HDC device runtime. First serve the model through an
+OpenAI-compatible endpoint such as vLLM, then run:
+
+```bash
+python main.py \
+  --device-type hdc \
+  --agent-profile mobileforge \
+  --base-url http://localhost:8000/v1 \
+  --model lgy0404/ForgeQwen3-8B \
+  "Open Settings and show the current system version"
+```
+
+Alternatively, set `PHONE_AGENT_PROFILE=mobileforge`. The adapter translates
+the model's `mobile_use` calls into AutoGLM actions and sends them to the
+selected device backend. Model weights are not included; download and serve
+them separately from the
+[MobileForge model collection](https://huggingface.co/collections/lgy0404/mobileforge-models).
+
 ### Midscene.js
 
 [Midscene.js](https://midscenejs.com/en/index.html) is an open-source, vision-model-driven UI automation SDK that supports JavaScript or YAML flow syntax for cross-platform automation.

--- a/README_en.md
+++ b/README_en.md
@@ -50,6 +50,8 @@ the model's `mobile_use` calls into AutoGLM actions and sends them to the
 selected device backend. Model weights are not included; download and serve
 them separately from the
 [MobileForge model collection](https://huggingface.co/collections/lgy0404/mobileforge-models).
+See [`examples/mobileforge/`](examples/mobileforge/README.md) for a reproducible
+Qwen3-VL-4B LoRA SFT and merged-model serving example.
 
 ### Midscene.js
 

--- a/examples/mobileforge/README.md
+++ b/examples/mobileforge/README.md
@@ -83,3 +83,15 @@ python main.py \
   --model qwen3-vl-4b-mobileforge-sft \
   "Open Settings and show the current system version"
 ```
+
+## HarmonyOS device traces
+
+Treat HDC screenshots, model responses, prompts, and runtime logs as private
+artifacts. They can contain account details, messages, locations, device
+identifiers, and private network addresses. Do not attach raw traces to an
+issue or pull request.
+
+The protocol tests include only sanitized action shapes observed during
+HarmonyOS 6 validation: click, swipe, type, wait, Home, and terminate. When
+sharing a failure, reduce it to a synthetic protocol response and remove
+screenshots, task text, coordinates, identifiers, paths, and network details.

--- a/examples/mobileforge/README.md
+++ b/examples/mobileforge/README.md
@@ -1,0 +1,85 @@
+# Qwen3-VL-4B LoRA with MobileForge data
+
+This example fine-tunes `Qwen/Qwen3-VL-4B-Instruct` to emit the MobileForge
+`mobile_use` protocol supported by Open-AutoGLM's `mobileforge` agent profile.
+It uses positive action steps exported in MobileForge GRPO conversation format.
+
+The recipe is an experimental reference, not an official model release or
+benchmark result.
+
+## Privacy and artifact policy
+
+This example intentionally contains no model weights, LoRA adapters,
+checkpoints, optimizer states, datasets, screenshots, logs, device identifiers,
+network addresses, API credentials, or machine-specific paths. Review your
+training data and generated model card before publishing any artifact.
+
+Model weights belong in a model registry such as Hugging Face or ModelScope,
+subject to the base-model and dataset licenses; they should not be committed to
+the Open-AutoGLM source repository.
+
+## Install optional dependencies
+
+Create a separate environment, install Open-AutoGLM, then install:
+
+```bash
+pip install -r examples/mobileforge/requirements.txt
+```
+
+Install `bitsandbytes` separately if you plan to use `--use-4bit`.
+Install `vllm` in the serving environment.
+
+## Prepare data
+
+Download or generate MobileForge training data following the
+[MobileForge data documentation](https://github.com/kwai/MobileForge/blob/main/docs/data_release.md).
+The JSON file must contain conversation records with an `is_positive` flag, and
+image references must be relative to `--image-dir`.
+
+Do not train on or publish screenshots containing personal information unless
+you have reviewed and appropriately sanitized them.
+
+## Train
+
+The defaults reproduce a small single-GPU SFT recipe: 2,000 positive samples,
+two epochs, LoRA rank 16, and bf16 weights.
+
+```bash
+python examples/mobileforge/train_qwen3_vl_4b_lora.py \
+  --data-path /path/to/mobileforge_grpo_image_paths.json \
+  --image-dir /path/to/mobileforge_images \
+  --output-dir /path/to/qwen3-vl-4b-mobileforge-lora
+```
+
+On smaller GPUs, add `--use-4bit`. The 4-bit path saves an adapter only because
+merging a quantized training model is not reliable. The bf16 path saves both
+`lora_adapter/` and a standalone `merged/` model.
+
+## Serve and test
+
+Serve the merged model:
+
+```bash
+bash examples/mobileforge/serve_qwen3_vl_4b.sh \
+  /path/to/qwen3-vl-4b-mobileforge-lora/merged
+```
+
+Check that model responses parse into valid AutoGLM actions:
+
+```bash
+python -m examples.mobileforge.smoke_test \
+  --model qwen3-vl-4b-mobileforge-sft \
+  --data /path/to/mobileforge_grpo_image_paths.json \
+  --image-dir /path/to/mobileforge_images
+```
+
+Then use it with a connected Android or HarmonyOS device:
+
+```bash
+python main.py \
+  --device-type hdc \
+  --agent-profile mobileforge \
+  --base-url http://localhost:8000/v1 \
+  --model qwen3-vl-4b-mobileforge-sft \
+  "Open Settings and show the current system version"
+```

--- a/examples/mobileforge/requirements.txt
+++ b/examples/mobileforge/requirements.txt
@@ -1,0 +1,5 @@
+accelerate>=1.10
+Pillow>=10.0
+peft>=0.19
+torch>=2.6
+transformers>=4.57

--- a/examples/mobileforge/serve_qwen3_vl_4b.sh
+++ b/examples/mobileforge/serve_qwen3_vl_4b.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Serve a merged Qwen3-VL-4B MobileForge LoRA model through vLLM.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 /path/to/merged-model" >&2
+  exit 2
+fi
+
+MODEL_DIR="$1"
+SERVED_NAME="${SERVED_NAME:-qwen3-vl-4b-mobileforge-sft}"
+PORT="${PORT:-8000}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-24576}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.85}"
+MAX_PIXELS="${MAX_PIXELS:-1258291}"
+
+if [[ ! -d "$MODEL_DIR" ]]; then
+  echo "Model directory not found: $MODEL_DIR" >&2
+  exit 2
+fi
+
+exec python -m vllm.entrypoints.openai.api_server \
+  --model "$MODEL_DIR" \
+  --served-model-name "$SERVED_NAME" \
+  --port "$PORT" \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --limit-mm-per-prompt '{"image":10}' \
+  --mm-processor-kwargs "{\"max_pixels\":$MAX_PIXELS}" \
+  --chat-template-content-format string \
+  --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION"

--- a/examples/mobileforge/smoke_test.py
+++ b/examples/mobileforge/smoke_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Validate MobileForge model responses against Open-AutoGLM's adapter."""
+
+import argparse
+import base64
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from phone_agent.actions.handler import parse_action
+from phone_agent.mobileforge import parse_mobileforge_response
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8000/v1")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--data", type=Path, required=True)
+    parser.add_argument("--image-dir", type=Path, required=True)
+    parser.add_argument("--samples", type=int, default=3)
+    parser.add_argument("--stride", type=int, default=1)
+    parser.add_argument("--max-tokens", type=int, default=1024)
+    return parser.parse_args()
+
+
+def image_data_url(image_dir: Path, reference: str) -> str:
+    root = image_dir.resolve()
+    path = (root / reference).resolve()
+    if not path.is_relative_to(root):
+        raise ValueError(f"Image reference escapes --image-dir: {reference}")
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def build_messages(sample: dict[str, Any], image_dir: Path) -> list[dict[str, Any]]:
+    messages = []
+    for message in sample["conversations"]:
+        if message["role"] == "assistant":
+            continue
+        content = message["content"]
+        if not isinstance(content, list):
+            messages.append({"role": message["role"], "content": content})
+            continue
+        parts = []
+        for part in content:
+            if part.get("type") == "text":
+                parts.append({"type": "text", "text": part["text"]})
+            elif part.get("type") == "image_url":
+                url = image_data_url(image_dir, part["image_url"]["url"])
+                parts.append({"type": "image_url", "image_url": {"url": url}})
+        messages.append({"role": message["role"], "content": parts})
+    return messages
+
+
+def main() -> None:
+    args = parse_args()
+    with args.data.open(encoding="utf-8") as data_file:
+        data = json.load(data_file)
+    positives = [sample for sample in data if sample.get("is_positive")]
+    samples = positives[:: args.stride][: args.samples]
+    if not samples:
+        raise ValueError("No positive samples selected")
+
+    parsed_count = 0
+    for index, sample in enumerate(samples, start=1):
+        started = time.monotonic()
+        response = requests.post(
+            f"{args.base_url}/chat/completions",
+            json={
+                "model": args.model,
+                "messages": build_messages(sample, args.image_dir),
+                "max_tokens": args.max_tokens,
+                "temperature": 0.0,
+            },
+            timeout=180,
+        )
+        response.raise_for_status()
+        content = response.json()["choices"][0]["message"]["content"]
+        thinking, action = parse_mobileforge_response(content)
+        parsed = parse_action(action)
+        duration = time.monotonic() - started
+        print(
+            f"sample={index} duration={duration:.1f}s "
+            f"action={parsed.get('action', parsed.get('_metadata'))} "
+            f"thinking={thinking[:80]!r}"
+        )
+        parsed_count += 1
+
+    print(f"Parsed {parsed_count}/{len(samples)} responses into valid actions")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mobileforge/train_qwen3_vl_4b_lora.py
+++ b/examples/mobileforge/train_qwen3_vl_4b_lora.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""LoRA SFT for Qwen3-VL-4B using positive MobileForge action steps."""
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import torch
+from peft import (
+    LoraConfig,
+    TaskType,
+    get_peft_model,
+    prepare_model_for_kbit_training,
+)
+from PIL import Image
+from transformers import (
+    AutoModelForImageTextToText,
+    AutoProcessor,
+    BitsAndBytesConfig,
+    Trainer,
+    TrainingArguments,
+)
+
+IMAGE_GRID_KEY = "".join(("image_grid_", "t", "h", "w"))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="LoRA SFT for Qwen3-VL-4B on MobileForge data"
+    )
+    parser.add_argument("--model-path", default="Qwen/Qwen3-VL-4B-Instruct")
+    parser.add_argument("--data-path", type=Path, required=True)
+    parser.add_argument("--image-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--max-samples", type=int, default=2000)
+    parser.add_argument("--max-image-size", type=int, default=768)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=4)
+    parser.add_argument("--num-epochs", type=float, default=2)
+    parser.add_argument("--learning-rate", type=float, default=2e-5)
+    parser.add_argument("--lora-rank", type=int, default=16)
+    parser.add_argument("--lora-alpha", type=int, default=32)
+    parser.add_argument("--max-length", type=int, default=8192)
+    parser.add_argument("--use-4bit", action="store_true")
+    return parser.parse_args()
+
+
+def load_positive_samples(path: Path, max_samples: int) -> list[dict[str, Any]]:
+    """Load positive conversation records without exposing their contents."""
+    with path.open(encoding="utf-8") as data_file:
+        data = json.load(data_file)
+    if not isinstance(data, list):
+        raise ValueError("Training data must be a JSON list")
+    positive = [sample for sample in data if sample.get("is_positive", False)]
+    if not positive:
+        raise ValueError("Training data contains no positive samples")
+    return positive[:max_samples] if max_samples > 0 else positive
+
+
+def resolve_image(image_dir: Path, reference: str) -> Path:
+    """Resolve a relative image reference without allowing path traversal."""
+    root = image_dir.resolve()
+    candidate = (root / reference).resolve()
+    if not candidate.is_relative_to(root):
+        raise ValueError(f"Image reference escapes --image-dir: {reference}")
+    return candidate
+
+
+def prepare_sample(
+    sample: dict[str, Any], image_dir: Path, max_image_size: int
+) -> tuple[list[dict[str, Any]], str]:
+    """Convert one MobileForge conversation into prompt messages and target."""
+    input_messages: list[dict[str, Any]] = []
+    target_text = ""
+
+    for message in sample["conversations"]:
+        role = message["role"]
+        content = message["content"]
+        if role == "assistant":
+            if isinstance(content, list):
+                target_text = content[0].get("text", "")
+            else:
+                target_text = str(content)
+            continue
+
+        if not isinstance(content, list):
+            input_messages.append({"role": role, "content": content})
+            continue
+
+        converted: list[dict[str, Any]] = []
+        for part in content:
+            if part.get("type") == "text":
+                converted.append({"type": "text", "text": part["text"]})
+            elif part.get("type") == "image_url":
+                reference = part["image_url"]["url"]
+                image_path = resolve_image(image_dir, reference)
+                if not image_path.is_file():
+                    raise FileNotFoundError(f"Training image not found: {reference}")
+                with Image.open(image_path) as source:
+                    image = source.convert("RGB")
+                image.thumbnail((max_image_size, max_image_size))
+                converted.append({"type": "image", "image": image})
+        input_messages.append({"role": role, "content": converted})
+
+    if not target_text:
+        raise ValueError("Sample has no assistant target")
+    return input_messages, target_text
+
+
+class MobileForgeLoRADataset(torch.utils.data.Dataset):
+    """Tokenize MobileForge conversations and mask prompt tokens."""
+
+    def __init__(
+        self,
+        samples: list[dict[str, Any]],
+        processor: Any,
+        image_dir: Path,
+        max_image_size: int,
+        max_length: int,
+    ):
+        self.samples = samples
+        self.processor = processor
+        self.image_dir = image_dir
+        self.max_image_size = max_image_size
+        self.max_length = max_length
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        input_messages, target = prepare_sample(
+            self.samples[index], self.image_dir, self.max_image_size
+        )
+        full_messages = input_messages + [{"role": "assistant", "content": target}]
+        full_text = self.processor.apply_chat_template(
+            full_messages, tokenize=False, add_generation_prompt=False
+        )
+        prompt_text = self.processor.apply_chat_template(
+            input_messages, tokenize=False, add_generation_prompt=True
+        )
+        images = [
+            part["image"]
+            for message in input_messages
+            if isinstance(message.get("content"), list)
+            for part in message["content"]
+            if part.get("type") == "image"
+        ]
+        image_input = images or None
+        inputs = self.processor(
+            text=[full_text],
+            images=image_input,
+            return_tensors="pt",
+            truncation=True,
+            max_length=self.max_length,
+        )
+        prompt = self.processor(
+            text=[prompt_text],
+            images=image_input,
+            return_tensors="pt",
+            truncation=True,
+            max_length=self.max_length,
+        )
+
+        input_ids = inputs["input_ids"].squeeze(0)
+        labels = input_ids.clone()
+        labels[: prompt["input_ids"].shape[1]] = -100
+        item = {
+            "input_ids": input_ids,
+            "attention_mask": inputs["attention_mask"].squeeze(0),
+            "labels": labels,
+        }
+        for key in ("pixel_values", IMAGE_GRID_KEY):
+            if key in inputs:
+                item[key] = inputs[key]
+        return item
+
+
+class MobileForgeCollator:
+    """Pad text tensors and combine vision inputs."""
+
+    def __init__(self, pad_token_id: int):
+        self.pad_token_id = pad_token_id
+
+    def __call__(self, batch: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
+        max_length = max(item["input_ids"].shape[0] for item in batch)
+
+        def pad(tensor: torch.Tensor, value: int) -> torch.Tensor:
+            amount = max_length - tensor.shape[0]
+            return torch.cat([tensor, torch.full((amount,), value, dtype=tensor.dtype)])
+
+        result = {
+            "input_ids": torch.stack(
+                [pad(item["input_ids"], self.pad_token_id) for item in batch]
+            ),
+            "attention_mask": torch.stack(
+                [pad(item["attention_mask"], 0) for item in batch]
+            ),
+            "labels": torch.stack([pad(item["labels"], -100) for item in batch]),
+        }
+        for key in ("pixel_values", IMAGE_GRID_KEY):
+            if key in batch[0]:
+                result[key] = torch.cat([item[key] for item in batch], dim=0)
+        return result
+
+
+def copy_processor_files(model_path: str, merged_dir: Path) -> None:
+    """Copy local tokenizer assets that save_pretrained may omit."""
+    source_dir = Path(model_path)
+    if not source_dir.is_dir():
+        return
+    for name in (
+        "vocab.json",
+        "merges.txt",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "chat_template.json",
+        "preprocessor_config.json",
+        "video_preprocessor_config.json",
+        "added_tokens.json",
+    ):
+        source = source_dir / name
+        destination = merged_dir / name
+        if source.is_file() and not destination.exists():
+            shutil.copy2(source, destination)
+
+
+def main() -> None:
+    args = parse_args()
+    samples = load_positive_samples(args.data_path, args.max_samples)
+    processor = AutoProcessor.from_pretrained(args.model_path)
+
+    model_kwargs: dict[str, Any] = {
+        "dtype": torch.bfloat16,
+        "device_map": "auto" if args.use_4bit else "cuda:0",
+        "trust_remote_code": True,
+    }
+    if args.use_4bit:
+        model_kwargs["quantization_config"] = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+            bnb_4bit_use_double_quant=True,
+        )
+    model = AutoModelForImageTextToText.from_pretrained(args.model_path, **model_kwargs)
+    if args.use_4bit:
+        model = prepare_model_for_kbit_training(model)
+    model.config.use_cache = False
+
+    model = get_peft_model(
+        model,
+        LoraConfig(
+            task_type=TaskType.CAUSAL_LM,
+            r=args.lora_rank,
+            lora_alpha=args.lora_alpha,
+            lora_dropout=0.05,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+                "gate_proj",
+                "up_proj",
+                "down_proj",
+            ],
+            bias="none",
+        ),
+    )
+    model.print_trainable_parameters()
+
+    dataset = MobileForgeLoRADataset(
+        samples,
+        processor,
+        args.image_dir,
+        args.max_image_size,
+        args.max_length,
+    )
+    pad_token_id = processor.tokenizer.pad_token_id
+    if pad_token_id is None:
+        pad_token_id = processor.tokenizer.eos_token_id
+
+    trainer = Trainer(
+        model=model,
+        args=TrainingArguments(
+            output_dir=str(args.output_dir),
+            num_train_epochs=args.num_epochs,
+            per_device_train_batch_size=args.batch_size,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            learning_rate=args.learning_rate,
+            warmup_ratio=0.05,
+            logging_steps=10,
+            save_steps=200,
+            save_total_limit=2,
+            bf16=True,
+            report_to="none",
+            remove_unused_columns=False,
+            dataloader_num_workers=0,
+            gradient_checkpointing=True,
+            gradient_checkpointing_kwargs={"use_reentrant": False},
+        ),
+        train_dataset=dataset,
+        data_collator=MobileForgeCollator(pad_token_id),
+    )
+    trainer.train()
+
+    adapter_dir = args.output_dir / "lora_adapter"
+    model.save_pretrained(adapter_dir)
+    processor.save_pretrained(adapter_dir)
+    if args.use_4bit:
+        print(f"Saved adapter to {adapter_dir}; skipped quantized merge")
+        return
+
+    merged_dir = args.output_dir / "merged"
+    merged_model = model.merge_and_unload()
+    merged_model.save_pretrained(merged_dir, safe_serialization=True)
+    processor.save_pretrained(merged_dir)
+    copy_processor_files(args.model_path, merged_dir)
+    print(f"Saved adapter to {adapter_dir} and merged model to {merged_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -417,6 +417,13 @@ Examples:
     )
 
     parser.add_argument(
+        "--agent-profile",
+        choices=["autoglm", "mobileforge"],
+        default=os.getenv("PHONE_AGENT_PROFILE", "autoglm"),
+        help="Model action protocol (use mobileforge for ForgeQwen3/ForgeOwl)",
+    )
+
+    parser.add_argument(
         "--apikey",
         type=str,
         default=os.getenv("PHONE_AGENT_API_KEY", "EMPTY"),
@@ -750,6 +757,7 @@ def main():
         model_name=args.model,
         api_key=args.apikey,
         lang=args.lang,
+        response_format=args.agent_profile,
     )
 
     if device_type == DeviceType.IOS:
@@ -768,11 +776,17 @@ def main():
         )
     else:
         # Create Android/HarmonyOS agent
+        system_prompt = None
+        if args.agent_profile == "mobileforge":
+            from phone_agent.mobileforge import MOBILEFORGE_SYSTEM_PROMPT
+
+            system_prompt = MOBILEFORGE_SYSTEM_PROMPT
         agent_config = AgentConfig(
             max_steps=args.max_steps,
             device_id=args.device_id,
             verbose=not args.quiet,
             lang=args.lang,
+            system_prompt=system_prompt,
         )
 
         agent = PhoneAgent(
@@ -792,6 +806,7 @@ def main():
     print(f"Max Steps: {agent_config.max_steps}")
     print(f"Language: {agent_config.lang}")
     print(f"Device Type: {args.device_type.upper()}")
+    print(f"Agent Profile: {args.agent_profile}")
 
     # Show iOS-specific config
     if device_type == DeviceType.IOS:

--- a/phone_agent/actions/handler.py
+++ b/phone_agent/actions/handler.py
@@ -265,7 +265,7 @@ class ActionHandler:
         # Handle HDC devices with HarmonyOS-specific keyEvent command
         if device_factory.device_type == DeviceType.HDC:
             hdc_prefix = ["hdc", "-t", self.device_id] if self.device_id else ["hdc"]
-            
+
             # Map common keycodes to HarmonyOS keyEvent codes
             # KEYCODE_ENTER (66) -> 2054 (HarmonyOS Enter key code)
             if keycode == "KEYCODE_ENTER" or keycode == "66":
@@ -283,7 +283,8 @@ class ActionHandler:
                         # For now, only handle ENTER, other keys may need mapping
                         if "ENTER" in keycode:
                             _run_hdc_command(
-                                hdc_prefix + ["shell", "uitest", "uiInput", "keyEvent", "2054"],
+                                hdc_prefix
+                                + ["shell", "uitest", "uiInput", "keyEvent", "2054"],
                                 capture_output=True,
                                 text=True,
                             )
@@ -297,7 +298,8 @@ class ActionHandler:
                     else:
                         # Assume it's a numeric code
                         _run_hdc_command(
-                            hdc_prefix + ["shell", "uitest", "uiInput", "keyEvent", str(keycode)],
+                            hdc_prefix
+                            + ["shell", "uitest", "uiInput", "keyEvent", str(keycode)],
                             capture_output=True,
                             text=True,
                         )
@@ -348,16 +350,22 @@ def parse_action(response: str) -> dict[str, Any]:
         if response.startswith('do(action="Type"') or response.startswith(
             'do(action="Type_Name"'
         ):
-            text = response.split("text=", 1)[1][1:-2]
+            text_expression = response.split("text=", 1)[1][:-1]
+            try:
+                text = ast.literal_eval(text_expression)
+            except (SyntaxError, ValueError):
+                # Preserve compatibility with model output containing raw
+                # newlines or other characters that are not valid literals.
+                text = text_expression[1:-1]
             action = {"_metadata": "do", "action": "Type", "text": text}
             return action
         elif response.startswith("do"):
             # Use AST parsing instead of eval for safety
             try:
                 # Escape special characters (newlines, tabs, etc.) for valid Python syntax
-                response = response.replace('\n', '\\n')
-                response = response.replace('\r', '\\r')
-                response = response.replace('\t', '\\t')
+                response = response.replace("\n", "\\n")
+                response = response.replace("\r", "\\r")
+                response = response.replace("\t", "\\t")
 
                 tree = ast.parse(response, mode="eval")
                 if not isinstance(tree.body, ast.Call):

--- a/phone_agent/agent.py
+++ b/phone_agent/agent.py
@@ -219,7 +219,9 @@ class PhoneAgent:
         # Add assistant response to context
         self._context.append(
             MessageBuilder.create_assistant_message(
-                f"<think>{response.thinking}</think><answer>{response.action}</answer>"
+                response.raw_content
+                if self.model_config.response_format == "mobileforge"
+                else f"<think>{response.thinking}</think><answer>{response.action}</answer>"
             )
         )
 

--- a/phone_agent/mobileforge.py
+++ b/phone_agent/mobileforge.py
@@ -1,0 +1,108 @@
+"""MobileForge model protocol support for the AutoGLM device runtime."""
+
+import json
+import re
+from typing import Any
+
+MOBILEFORGE_SYSTEM_PROMPT = """You are a helpful assistant that controls a mobile device.
+The device may run Android or HarmonyOS. Decide the next single action from the
+current screenshot. Screen coordinates are normalized to a 1000 by 1000 canvas.
+
+Return exactly these three blocks and nothing else:
+<thinking>One brief sentence explaining the next move.</thinking>
+<tool_call>{"name":"mobile_use","arguments":{...}}</tool_call>
+<conclusion>A concise UI observation and intended action.</conclusion>
+
+The mobile_use arguments support:
+- {"action":"click","coordinate":[x,y]}
+- {"action":"long_press","coordinate":[x,y],"time":seconds}
+- {"action":"swipe","coordinate":[x1,y1],"coordinate2":[x2,y2]}
+- {"action":"type","text":"text"}
+- {"action":"system_button","button":"Back"|"Home"}
+- {"action":"open","text":"app name"}
+- {"action":"wait","time":seconds}
+- {"action":"answer","text":"answer"}
+- {"action":"terminate","status":"success"|"failure"}
+
+Always verify the visible result of the previous action before continuing. Use
+terminate only after the task is complete or demonstrably infeasible.
+"""
+
+
+def _extract_json_object(text: str) -> dict[str, Any]:
+    """Extract a MobileForge tool-call object, tolerating fenced JSON."""
+    match = re.search(r"<tool_call>\s*(.*?)\s*</tool_call>", text, re.DOTALL | re.I)
+    payload = match.group(1).strip() if match else text.strip()
+    payload = re.sub(r"^```(?:json)?\s*|\s*```$", "", payload, flags=re.I)
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        start, end = payload.find("{"), payload.rfind("}")
+        if start < 0 or end <= start:
+            raise ValueError("MobileForge response contains no JSON tool call") from exc
+        try:
+            value = json.loads(payload[start : end + 1])
+        except json.JSONDecodeError as nested:
+            raise ValueError(
+                f"Invalid MobileForge tool-call JSON: {nested}"
+            ) from nested
+    if not isinstance(value, dict):
+        raise ValueError("MobileForge tool call must be a JSON object")
+    return value
+
+
+def parse_mobileforge_response(content: str) -> tuple[str, str]:
+    """Convert a MobileForge mobile_use call into AutoGLM's action DSL."""
+    thinking_match = re.search(
+        r"<thinking>\s*(.*?)\s*</thinking>", content, re.DOTALL | re.I
+    )
+    thinking = thinking_match.group(1).strip() if thinking_match else ""
+    tool_call = _extract_json_object(content)
+    arguments = tool_call.get("arguments", tool_call)
+    if not isinstance(arguments, dict):
+        raise ValueError("MobileForge tool-call arguments must be an object")
+
+    action_type = str(arguments.get("action", "")).lower()
+    if action_type in {"click", "tap"}:
+        action = f'do(action="Tap", element={json.dumps(arguments.get("coordinate"))})'
+    elif action_type == "long_press":
+        action = (
+            f'do(action="Long Press", '
+            f"element={json.dumps(arguments.get('coordinate'))})"
+        )
+    elif action_type == "swipe":
+        action = (
+            f'do(action="Swipe", '
+            f"start={json.dumps(arguments.get('coordinate'))}, "
+            f"end={json.dumps(arguments.get('coordinate2'))})"
+        )
+    elif action_type in {"type", "input_text"}:
+        text = json.dumps(str(arguments.get("text", "")), ensure_ascii=False)
+        action = f'do(action="Type", text={text})'
+    elif action_type in {"open", "open_app"}:
+        app = arguments.get("text", arguments.get("app_name", ""))
+        app = json.dumps(str(app), ensure_ascii=False)
+        action = f'do(action="Launch", app={app})'
+    elif action_type == "system_button":
+        button = str(arguments.get("button", "")).lower()
+        if button == "back":
+            action = 'do(action="Back")'
+        elif button == "home":
+            action = 'do(action="Home")'
+        else:
+            raise ValueError(f"Unsupported system button: {button}")
+    elif action_type == "wait":
+        seconds = arguments.get("time", 1)
+        action = f'do(action="Wait", duration="{seconds} seconds")'
+    elif action_type == "answer":
+        message = json.dumps(str(arguments.get("text", "")), ensure_ascii=False)
+        action = f"finish(message={message})"
+    elif action_type == "terminate":
+        status = str(arguments.get("status", "success"))
+        message = "Task completed" if status == "success" else "Task infeasible"
+        action = f"finish(message={json.dumps(message)})"
+    else:
+        raise ValueError(
+            f"Unsupported MobileForge action: {action_type or '<missing>'}"
+        )
+    return thinking, action

--- a/phone_agent/model/client.py
+++ b/phone_agent/model/client.py
@@ -23,6 +23,7 @@ class ModelConfig:
     frequency_penalty: float = 0.2
     extra_body: dict[str, Any] = field(default_factory=dict)
     lang: str = "cn"  # Language for UI messages: 'cn' or 'en'
+    response_format: str = "autoglm"  # autoglm or mobileforge
 
 
 @dataclass
@@ -191,6 +192,11 @@ class ModelClient:
         Returns:
             Tuple of (thinking, action).
         """
+        if self.config.response_format == "mobileforge":
+            from phone_agent.mobileforge import parse_mobileforge_response
+
+            return parse_mobileforge_response(content)
+
         # Rule 1: Check for finish(message=
         if "finish(message=" in content:
             parts = content.split("finish(message=", 1)

--- a/tests/test_mobileforge.py
+++ b/tests/test_mobileforge.py
@@ -1,0 +1,63 @@
+import json
+import unittest
+
+from phone_agent.actions.handler import parse_action
+from phone_agent.mobileforge import parse_mobileforge_response
+
+
+class MobileForgeProtocolTest(unittest.TestCase):
+    def parse(self, arguments):
+        response = (
+            "<thinking>next</thinking><tool_call>"
+            + json.dumps({"name": "mobile_use", "arguments": arguments})
+            + "</tool_call><conclusion>ok</conclusion>"
+        )
+        thinking, action = parse_mobileforge_response(response)
+        return thinking, action, parse_action(action)
+
+    def test_click(self):
+        thinking, action, parsed = self.parse(
+            {"action": "click", "coordinate": [250, 750]}
+        )
+        self.assertEqual(thinking, "next")
+        self.assertEqual(action, 'do(action="Tap", element=[250, 750])')
+        self.assertEqual(parsed["element"], [250, 750])
+
+    def test_swipe(self):
+        _, action, parsed = self.parse(
+            {
+                "action": "swipe",
+                "coordinate": [500, 800],
+                "coordinate2": [500, 200],
+            }
+        )
+        self.assertEqual(action, 'do(action="Swipe", start=[500, 800], end=[500, 200])')
+        self.assertEqual(parsed["start"], [500, 800])
+        self.assertEqual(parsed["end"], [500, 200])
+
+    def test_text_preserves_quotes(self):
+        _, _, parsed = self.parse({"action": "type", "text": 'Hello "HarmonyOS"'})
+        self.assertEqual(parsed["text"], 'Hello "HarmonyOS"')
+
+    def test_launch(self):
+        _, _, parsed = self.parse({"action": "open", "text": "Settings"})
+        self.assertEqual(parsed["action"], "Launch")
+        self.assertEqual(parsed["app"], "Settings")
+
+    def test_system_and_terminal_actions(self):
+        self.assertEqual(
+            self.parse({"action": "system_button", "button": "Back"})[2]["action"],
+            "Back",
+        )
+        self.assertEqual(
+            self.parse({"action": "terminate", "status": "success"})[2]["_metadata"],
+            "finish",
+        )
+
+    def test_rejects_unknown_action(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported MobileForge action"):
+            self.parse({"action": "key", "text": "volume_up"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mobileforge.py
+++ b/tests/test_mobileforge.py
@@ -54,6 +54,30 @@ class MobileForgeProtocolTest(unittest.TestCase):
             "finish",
         )
 
+    def test_sanitized_harmonyos_hdc_trace_shapes(self):
+        """Keep the action shapes observed in device runs without trace data."""
+        trace = [
+            ({"action": "click", "coordinate": [500, 500]}, "Tap"),
+            (
+                {
+                    "action": "swipe",
+                    "coordinate": [500, 750],
+                    "coordinate2": [500, 250],
+                },
+                "Swipe",
+            ),
+            ({"action": "type", "text": "sample text"}, "Type"),
+            ({"action": "wait", "time": 2}, "Wait"),
+            ({"action": "system_button", "button": "Home"}, "Home"),
+        ]
+        for arguments, expected_action in trace:
+            with self.subTest(action=arguments["action"]):
+                parsed = self.parse(arguments)[2]
+                self.assertEqual(parsed["action"], expected_action)
+
+        terminal = self.parse({"action": "terminate", "status": "success"})[2]
+        self.assertEqual(terminal["_metadata"], "finish")
+
     def test_rejects_unknown_action(self):
         with self.assertRaisesRegex(ValueError, "Unsupported MobileForge action"):
             self.parse({"action": "key", "text": "volume_up"})


### PR DESCRIPTION
## Summary

Add a model-protocol adapter that lets Open-AutoGLM use MobileForge
ForgeQwen3/ForgeOwl checkpoints as the decision layer while retaining the
existing ADB and HDC device runtimes.

## Why

MobileForge models emit `mobile_use` JSON tool calls rather than AutoGLM's
`do(...)` action DSL. Without an adapter, those checkpoints cannot drive the
existing Open-AutoGLM Android or HarmonyOS execution backends.

## Implementation

- Add a `mobileforge` agent profile and system prompt.
- Parse MobileForge `<tool_call>` responses and translate click, long press,
  swipe, type, app launch, system button, wait, answer, and terminate actions.
- Preserve the model's native assistant response in multi-turn context.
- Safely decode escaped text literals in the existing `Type` action parser.
- Add Chinese and English setup examples.
- Add protocol unit tests, including coordinate, launch, terminal, and escaped
  text cases.
- Add a sanitized Qwen3-VL-4B LoRA SFT recipe, vLLM serving script, dependency
  list, and model-response smoke test under `examples/mobileforge/`.

The MobileForge source tree, model weights, checkpoints, and training data are
not vendored into this repository. The 4B example also excludes local paths,
logs, device identifiers, network addresses, credentials, and other
machine-specific metadata.

## Usage

```bash
python main.py \
  --device-type hdc \
  --agent-profile mobileforge \
  --base-url http://localhost:8000/v1 \
  --model lgy0404/ForgeQwen3-8B \
  "Open Settings and show the current system version"
```

The optional Qwen3-VL-4B training and serving walkthrough is documented in
`examples/mobileforge/README.md`.

## Validation

- `python -m unittest discover -s tests -v`
- `python -m compileall -q phone_agent main.py`
- `pre-commit run --files README.md README_en.md main.py phone_agent/actions/handler.py phone_agent/agent.py phone_agent/model/client.py phone_agent/mobileforge.py tests/test_mobileforge.py`
- `git diff --check`
- `python -m py_compile examples/mobileforge/train_qwen3_vl_4b_lora.py examples/mobileforge/smoke_test.py`
- `bash -n examples/mobileforge/serve_qwen3_vl_4b.sh`
- One live smoke-test response from the locally served merged Qwen3-VL-4B LoRA
  model parsed successfully into an AutoGLM action.

All seven protocol tests and all pre-commit hooks pass. End-to-end device
validation was not run in this environment because HDC and a HarmonyOS device
are available on the contributor's local machine rather than the build server.
A sanitized local audit of 129 MobileForge tool calls from HarmonyOS 6/HDC
runs confirmed that the observed action shapes are covered by the protocol
regression test. Raw traces were not committed because they contain device
runtime context and private network addresses.