### PR TITLE
fix: ensure temp screenshot file cleanup on error paths

### DIFF
--- a/phone_agent/adb/screenshot.py
+++ b/phone_agent/adb/screenshot.py
@@ -73,9 +73,6 @@ def get_screenshot(device_id: str | None = None, timeout: int = 10) -> Screensho
         img.save(buffered, format="PNG")
         base64_data = base64.b64encode(buffered.getvalue()).decode("utf-8")
 
-        # Cleanup
-        os.remove(temp_path)
-
         return Screenshot(
             base64_data=base64_data, width=width, height=height, is_sensitive=False
         )
@@ -83,6 +80,10 @@ def get_screenshot(device_id: str | None = None, timeout: int = 10) -> Screensho
     except Exception as e:
         print(f"Screenshot error: {e}")
         return _create_fallback_screenshot(is_sensitive=False)
+    finally:
+        # Ensure temp file is cleaned up even on error paths
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
 
 
 def _get_adb_prefix(device_id: str | None) -> list:


### PR DESCRIPTION
## What this PR fixes

The ADB screenshot capture flow creates a temporary file in the system temp directory, but only cleaned it up in the happy-path execution. If Image.open() or any downstream operation (save, base64 encode) raised an exception, the temp file would leak in /tmp/.

## Changes

- Move os.remove(temp_path) from the success path into a finally block
- The finally block checks os.path.exists(temp_path) before removing, making it safe for all code paths including early returns for sensitive screens

## Why this matters

Long-running automation sessions that encounter repeated screenshot errors can accumulate orphaned temp files, eventually filling the temp directory and causing filesystem issues.
