### PR TITLE
fix: remove unused Tuple imports from screenshot modules

### DIFF
--- a/phone_agent/adb/screenshot.py
+++ b/phone_agent/adb/screenshot.py
@@ -7,7 +7,6 @@ import tempfile
 import uuid
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Tuple
 
 from PIL import Image
 

--- a/phone_agent/hdc/screenshot.py
+++ b/phone_agent/hdc/screenshot.py
@@ -7,7 +7,6 @@ import tempfile
 import uuid
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Tuple
 
 from PIL import Image
 from phone_agent.hdc.connection import _run_hdc_command


### PR DESCRIPTION
## What this PR fixes

Both `phone_agent/adb/screenshot.py` and `phone_agent/hdc/screenshot.py` import `Tuple` from `typing` but never use it. These dead imports add noise and would trigger linting warnings in strict environments (e.g. `flake8` F401, `ruff` unused-import).

## Changes

- Remove unused `from typing import Tuple` from `phone_agent/adb/screenshot.py`
- Remove unused `from typing import Tuple` from `phone_agent/hdc/screenshot.py`

## Notes

No functional changes — this is purely a code quality cleanup.
