### PR TITLE
fix: prevent stderr from corrupting IME identifier in keyboard detection

### DIFF
--- a/phone_agent/adb/input.py
+++ b/phone_agent/adb/input.py
@@ -71,7 +71,7 @@ def detect_and_set_adb_keyboard(device_id: str | None = None) -> str:
         capture_output=True,
         text=True,
     )
-    current_ime = (result.stdout + result.stderr).strip()
+    current_ime = result.stdout.strip() if result.returncode == 0 else ""
 
     # Switch to ADB Keyboard if not already set
     if "com.android.adbkeyboard/.AdbIME" not in current_ime:

--- a/phone_agent/hdc/input.py
+++ b/phone_agent/hdc/input.py
@@ -112,7 +112,7 @@ def detect_and_set_adb_keyboard(device_id: str | None = None) -> str:
             capture_output=True,
             text=True,
         )
-        current_ime = (result.stdout + result.stderr).strip()
+        current_ime = result.stdout.strip() if result.returncode == 0 else ""
 
         # If ADB Keyboard equivalent exists for HarmonyOS, switch to it
         # For now, we'll just return the current IME


### PR DESCRIPTION
This PR addresses: prevent stderr from corrupting IME identifier in keyboard detection